### PR TITLE
Add Invert fn & icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
                 </div>
 
                 <div class='col col--4 col--8-mm'>
+                    <button @click="invert" v-if='reverse' class='fl btn h36 round bg-default transition bg-default-dark-on-hover color-blue-on-hover'><svg class='icon'><use href='#icon-rotate'></use></svg></button>
                     <button @click="panelManage('settings')" class='fr btn h36 round bg-default transition bg-default-dark-on-hover color-blue-on-hover'><svg class='icon'><use href='#icon-sprocket'/></svg></button>
                     <button @click="bugReport" class='fr btn h36 round bg-default transition bg-default-dark-on-hover color-blue-on-hover'><svg class='icon'><use href='#icon-bug'></use></svg></button>
                     <button @click="shareClick" class='fr btn h36 round bg-default transition bg-default-dark-on-hover color-blue-on-hover'><svg class='icon'><use href='#icon-share'/></svg></button>

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ window.onload = () => {
                 },
             },
             bbox: { type: 'FeatureCollection', features: [] },
+            reverse: false,
             query: '',
             url: '',
             saved: [],
@@ -274,6 +275,8 @@ window.onload = () => {
                     }
                 });
             });
+
+            this.search();
         },
         // watch functions are triggered by user interactions which change values in the `data` property
         watch: {
@@ -520,6 +523,11 @@ window.onload = () => {
                     }]
                 }
             },
+            invert: function() {
+                console.error(this.query);
+                this.query = this.query.split(',').reverse().join(',');
+                this.geocoderResults.features = [];
+            },
             search: function() {
                 let searchTime = new Date();
                 this.updateHash();
@@ -531,11 +539,14 @@ window.onload = () => {
 
                 //Check if it is a reverse query and drop a point on the map if it is
                 if (this.map && this.query.split(',').length === 2 && !isNaN(Number(this.query.split(',')[0])) && !isNaN(Number(this.query.split(',')[1]))) {
+                    this.reverse = true;
                     const el = document.createElement('div');
                     el.className = 'marker';
                     el.style.backgroundImage = 'url(' + require('./img/dot.png') +')';
                     this.reverseMarker = new mapboxgl.Marker(el).setLngLat([Number(this.query.split(',')[0]), Number(this.query.split(',')[1])]);
                     this.reverseMarker.addTo(this.map);
+                } else {
+                    this.reverse = false;
                 }
 
                 let env = this.cnf.staging ? 'staging' : 'production';


### PR DESCRIPTION
Closes: https://github.com/mapbox/search-playground/issues/2

I was driven crazy today debugging a couple coordinates and it motivated me to get this one implemented.

_Forward Query - No Invert Button_
![screenshot from 2018-10-10 11-17-12](https://user-images.githubusercontent.com/1297009/46746980-2f852280-cc7e-11e8-8a5a-1efa9acf21cc.png)

_Reverse Query - Invert Button_
![screenshot from 2018-10-10 11-17-05](https://user-images.githubusercontent.com/1297009/46747009-3f9d0200-cc7e-11e8-9d50-8398f89e5e17.png)

_Invert coords now work!_
![screenshot from 2018-10-10 11-16-59](https://user-images.githubusercontent.com/1297009/46747023-4592e300-cc7e-11e8-8607-9e7d22d21822.png)

cc/ @mapbox/search 