### PR TITLE
fix parcel command in `start` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "ingalls <ingalls@protonmail.com>",
   "license": "MIT",
   "scripts": {
-    "start": "parcel",
+    "start": "parcel index.html",
     "build": "parcel build index.html -d _site --no-minify --public-url='/search-playground/'"
   },
   "dependencies": {


### PR DESCRIPTION
To run the app locally, we tell users to run `yarn start`, which runs `parcel`.  According to the the parceljs.org docs, though, the correct invocation is `parcel index.html`.  Changing this fixes the behavior and makes it possible to host the app locally.