### PR TITLE
Accuracy and Intersections

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,17 +279,22 @@
                     <div class='resultsList'>
                         <div v-for="(res, res_it) res in (cnf.onDebug ? vtQueryResults.features: geocoderResults.features)" class="res clearfix" :result="res_it" @mouseenter="resultEnter" @mouseleave="resultLeave" @click="resultClick">
                             <template v-if="res.id.toString().split('.')[0] == 'address'">
-                                <template v-if="res.geometry.interpolated"> <!-- Show Icon for Interpolated Address -->
+                                <template v-if="res.properties.accuracy === 'interpolated'">
                                     <div class="resIcon" :result="res_it">
                                         <svg class='icon'><use href='#icon-point-line'/></svg>
                                     </div>
                                 </template>
-                                <template v-else-if="!res.address"> <!-- If it doesn't have address property it is a street -->
+                                <template v-else-if="res.properties.accuracy === 'street'">
                                     <div class="resIcon" :result="res_it">
                                         <svg class='icon'><use href='#icon-line'/></svg>
                                     </div>
                                 </template>
-                                <template v-else> <!-- Everything else are address points -->
+                                <template v-else-if="res.properties.accuracy === 'intersection'">
+                                    <div class="resIcon" :result="res_it">
+                                        <svg class='icon'><use href='#icon-plus'/></svg>
+                                    </div>
+                                </template>
+                                <template v-else>
                                     <div class="resIcon" :result="res_it">
                                         <svg class='icon'><use href='#icon-marker'/></svg>
                                     </div>


### PR DESCRIPTION
- Instead of parsing full response to determine icon - use the `accuracy` property
- Add support for intersection icons :tada: 

