### PR TITLE
Add 'local' yarn script for using local api-geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Parameters available in the playground:
 
 ## Run it locally with parcel
     yarn install
+    yarn build
     yarn start
 ## Deploying
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "scripts": {
     "start": "parcel index.html",
-    "build": "parcel build index.html -d _site --no-minify --public-url='/search-playground/'"
+    "build": "parcel build index.html -d _site --no-minify --public-url='/search-playground/'",
+    "local": "export DEPLOY_ENV='local' && parcel index.html serve -d _site --public-url='/search-playground/'"
   },
   "dependencies": {
     "@vue/component-compiler-utils": "^1.3.1",

--- a/src/main.js
+++ b/src/main.js
@@ -17,8 +17,9 @@ window.onload = () => {
                     key_hiero_federation: 'pk.eyJ1IjoiYXBleHNlYXJjaHVzZXIiLCJhIjoiY2pxc2V6bjVyMHVxcjQ4cXE4cmg1a242diJ9.TMZ9oWhH_fF4ccYkaMeyAw'
                 },
                 staging: {
-                    url: 'https://api-geocoder-staging.tilestream.net/geocoding/v5',
-                    key: false
+                    url: process.env.DEPLOY_ENV === 'local' ? 'http://localhost:8000/geocoding/v5': 'https://api-geocoder-staging.tilestream.net/geocoding/v5',
+                    key: process.env.DEPLOY_ENV === 'local' ? 'pk.eyJ1IjoiYXBpa2V5dXNlciIsImEiOiJhYmNkZWZnIn0.ENonA568sn1Xp32NR6CvxA': false,
+                    authed: process.env.DEPLOY_ENV === 'local' ? true : false
                 },
                 map: {
                     key: 'pk.eyJ1Ijoic2JtYTQ0IiwiYSI6ImNpcXNycTNqaTAwMDdmcG5seDBoYjVkZGcifQ.ZVIe6sjh0QGeMsHpBvlsEA'
@@ -26,7 +27,7 @@ window.onload = () => {
                 debug: {
                     url: 'https://api.mapbox.com/geocoding/v5/tiles',
                     key: '',
-                    authed: false
+                    authed: process.env.DEPLOY_ENV === 'local' ? true : false
                 },
                 heyProxy: {
                     url: 'https://hey.mapbox.com/search-playground/geocoding-debug'


### PR DESCRIPTION
### Context
This PR adds a script for running search-playground against a local geocoding api endpoint.


### Summary of changes
- [x] Adds `yarn local` script to set an environment variable and use `localhost:8000` as the geocoding api host when the `staging` toggle is enabled.

### Next steps
- [x] Test to make sure this works on publisher-staging