### PR TITLE
Update link for API docs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -308,7 +308,7 @@ window.onload = () => {
         },
         // methods functions perform CRUD operations on the `data` property
         methods: {
-            help: function(url = 'https://www.mapbox.com/api-documentation/#search-for-places') {
+            help: function(url = 'https://docs.mapbox.com/api/search/#forward-geocoding') {
                 window.open(url, '_blank');
             },
             //Parse Settings from a Mapbox API URL


### PR DESCRIPTION
@simrend pointed out that the informational links in the Search Playground were not being redirected to the correct API documentation endpoint. This PR fixes that. @Nmargolis and/or @karenell to review, please!