### PR TITLE
Enable Federation Search Options

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 <body>
   <div id='app' class='relative'>
     <div class='grid grid--gut12 py12 px12 bg-default'>
-      <template v-if='cnf.type === "poi-category"'>
+      <template v-if='cnf.type === "poi-category" || cnf.type === "unified"'>
         <div class='col col--4 relative'>
           <div class='absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36'><svg class='icon'>
               <use href='#icon-search'></use>
@@ -179,6 +179,10 @@
                   <label class="toggle-container">
                     <input :checked="cnf.type == 'poi-category'" name='toggle-1' @click="typeClick" type='radio' value="poi-category" />
                     <div class="toggle">POI Category</div>
+                  </label>
+                  <label class="toggle-container">
+                    <input :checked="cnf.type == 'unified'" name='toggle-1' @click="typeClick" type='radio' value="unified" />
+                    <div class="toggle">Unified Search</div>
                   </label>
                 </div>
               </div>

--- a/src/main.js
+++ b/src/main.js
@@ -15,8 +15,8 @@ window.onload = () => {
                     suggestUrl: 'https://search-federation-production.mapbox.com/api/v1/suggest',
                     retrieveUrl: 'https://search-federation-production.mapbox.com/api/v1/retrieve',
                     poiUrl: 'https://api-poi-search-production.mapbox.com',
-                    unifiedSuggestUrl: 'http://search-federation-staging.tilestream.net/search/v0.0/suggest',
-                    unifiedRetrieveUrl: 'http://search-federation-staging.tilestream.net/search/v0.0/retrieve',
+                    unifiedSuggestUrl: 'https://search-federation-production.mapbox.com/search/v0.0/suggest',
+                    unifiedRetrieveUrl: 'https://search-federation-production.mapbox.com/search/v0.0/retrieve',
                     key_federation: 'pk.eyJ1IjoibWF0dGZpY2tlIiwiYSI6ImNqNnM2YmFoNzAwcTMzM214NTB1NHdwbnoifQ.Or19S7KmYPHW8YjRz82v6g'
                 },
                 map: {


### PR DESCRIPTION
Update to Playground include federated 'suggest' and 'retrieve' endpoints in new 'Unified Search' view.
- Add Toggle for Unified Search
- Enable Selection of Categories and Addresses
- Keep the Selection Box Visible after Selection
- Move to the Address after Selection