### PR TITLE
Enable worldviews filter on search playground

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,21 @@
                             </div>
                         </div>
 
+                        <!--Worldview Filter-->
+                        <div class='col col--12'>
+                            <div class="col col--12 py12">
+                                <label class='switch-container fl pr12'>
+                                    <input v-model="cnf.onWorldview" type='checkbox' checked/>
+                                    <div class='switch'></div>
+                                </label>
+                                <h3 class='txt-h4'>Worldview Filter <svg @click="help()" class='fr ml12 icon cursor-pointer color-gray-light color-gray-dark-on-hover'><use href='#icon-info'/></svg></h3>
+                            </div>
+
+                            <div class="col col--12 px48">
+                                <multiselect v-model="cnf.worldviews" :options="worldviews" placeholder="Filter" :taggable="true" :multiple="true"  track-by="code" label="name"></multiselect>
+                            </div>
+                        </div>
+
                         <!-- Types Filter -->
                         <div class='col col--12'>
                             <div class='col col--12 py12'>

--- a/src/main.js
+++ b/src/main.js
@@ -49,6 +49,12 @@ window.onload = () => {
             // Results from querying vector tiles
             vtQueryResults: { type: 'FeatureCollection', features: [] },
             countries: [],
+            worldviews: [
+                { code: 'cn', name: 'China' },
+                { code: 'in', name: 'India' },
+                { code: 'jp', name: 'Japan' },
+                { code: 'us', name: 'US (De facto)' }
+            ],
             languages: [
                 { code: 'ar', name: 'Arabic' },
                 { code: 'az', name: 'Azerbaijani' },
@@ -119,12 +125,14 @@ window.onload = () => {
                 approx: true,
                 staging: false,
                 onCountry: true,
+                onWorldview: true,
                 onType: true,
                 onProximity: true,
                 onBBOX: true,
                 onLimit: true,
                 onLanguage: true,
                 countries: [],
+                worldviews: [],
                 proximity: '',
                 typeToggle: {
                     'country': false,
@@ -298,6 +306,8 @@ window.onload = () => {
             'cnf.approx': function() { return this.search(); },
             'cnf.onCountry': function() { return this.search(); },
             'cnf.countries': function() { return this.search(); },
+            'cnf.onWorldview': function() { return this.search(); },
+            'cnf.worldviews': function() { return this.search(); },
             'cnf.onType': function() { return this.search(); },
             'cnf.types': function() { return this.search(); },
             'cnf.onProximity': function() { return this.search(); },
@@ -344,6 +354,21 @@ window.onload = () => {
                                 name: country.toUpperCase(),
                                 code: country
                             });
+                        });
+                    } else if (entry[0] === 'worldview') {
+                        entry[1].split(',').map((wView) => {
+                            return wView.toLowerCase();
+                        }).forEach((wView) => {
+                            let found_wv;
+                            for (let l of this.worldviews) {
+                                if (l.code === wView) found_wv = l;
+                            }
+
+                            if (found_wv) {
+                                this.cnf.worldviews.push(found_wv);
+                            } else {
+                                this.cnf.worldviews.push({ name: wView, code: wView });
+                            }
                         });
                     } else if (entry[0] === 'bbox') {
                         this.cnf.bbox = entry[1];
@@ -574,6 +599,7 @@ window.onload = () => {
                 url = `${url}&autocomplete=${this.cnf.autocomplete ? 'true' : 'false'}`;
 
                 if (this.cnf.onCountry && this.cnf.countries.length) url = `${url}&country=${encodeURIComponent(this.cnf.countries.map((country) => { return country.code }).join(','))}`;
+                if (this.cnf.onWorldview && this.cnf.worldviews.length) url = `${url}&worldview=${encodeURIComponent(this.cnf.worldviews.map((wView) => { return wView.code }).join(','))}`;
                 if (this.cnf.onType && this.cnf.types.length) url = `${url}&types=${encodeURIComponent(this.cnf.types)}`;
                 if (this.cnf.onProximity && this.cnf.proximity) url = `${url}&proximity=${encodeURIComponent(this.cnf.proximity)}`;
                 if (this.cnf.onBBOX && this.cnf.bbox) url = `${url}&bbox=${encodeURIComponent(this.cnf.bbox)}`;


### PR DESCRIPTION
Adding worldviews filter in Search Playground that uses the `worldview` parameter from the API response and currently hardcodes to 4 worldviews (US, China, India, and Japan) that Mapbox Search supports at present. Here are  some example queries:

_Worldview filter set to `India`_
![Screenshot 2020-06-19 at 11 27 32 PM](https://user-images.githubusercontent.com/17143802/85170457-0d350c00-b28b-11ea-9f73-326ec76f9337.png)

_Worldview filter toggled off but set to `India`_
![Screenshot 2020-06-19 at 11 27 42 PM](https://user-images.githubusercontent.com/17143802/85170463-0dcda280-b28b-11ea-8061-e8664814fc5a.png)

_Worldview filter toggled ON & set to `China`_
![Screenshot 2020-06-19 at 11 28 14 PM](https://user-images.githubusercontent.com/17143802/85170476-11f9c000-b28b-11ea-9513-c03e896aa649.png)

---

<details>
<summary><b>Screenshots from more trials</b></summary>

_Worldview filter toggled ON & set to `China`_
![Screenshot 2020-06-20 at 12 17 51 AM](https://user-images.githubusercontent.com/17143802/85171032-e1665600-b28b-11ea-80b4-dc1581e9ffee.png)

_Worldview filter toggled OFF & set to `China`_
![Screenshot 2020-06-20 at 12 18 24 AM](https://user-images.githubusercontent.com/17143802/85171050-ea572780-b28b-11ea-9e92-2b11870c481c.png)

_Worldview filter toggled ON but not set with any value(`<empty>`)_
![Screenshot 2020-06-20 at 12 18 00 AM](https://user-images.githubusercontent.com/17143802/85171042-e75c3700-b28b-11ea-9866-43d10ace9c16.png)

_Worldview filter toggled ON & set to `US (De facto)`_
![Screenshot 2020-06-20 at 12 18 11 AM](https://user-images.githubusercontent.com/17143802/85171048-e88d6400-b28b-11ea-9f65-eaa090816106.png)

</details>

