### PR TITLE
Handle other 2xx

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -324,7 +324,7 @@ window.onload = () => {
                         this.geocoderResults.features = []; //Clear Results
                         this.suggestResults = []; //Clear Results
 
-                        if (xhr.status !== 200) {
+                        if (xhr.status < 200 || xhr.status > 299) {
                             //TODO ERROR HANDLING
                         } else {
                             if (this.cnf.type === 'address' || this.cnf.type === 'unified') {
@@ -463,7 +463,7 @@ window.onload = () => {
 
                             this.geocoderResults.features = []; // clear results
 
-                            if (xhr.status !== 200) {
+                            if (xhr.status < 200 || xhr.status > 299) {
                                 //TODO ERROR HANDLING
                             } else {
                                 let feat = JSON.parse(xhr.responseText)[0].features[0];


### PR DESCRIPTION
This change allows for API responses with all 2XX level status codes to be accepted and displayed on the playground. This change is necessary to allow partial content responses (status code 206) from SBS to be displayed on the playground. 

cc: @mapbox/search-federation 